### PR TITLE
Use GL 3.2 to illustrate multiple glow package use.

### DIFF
--- a/glow/cube/cube.go
+++ b/glow/cube/cube.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"fmt"
 	glfw "github.com/go-gl/glfw3"
+	gl32 "github.com/go-gl/glow/gl-core/3.2/gl"
 	"github.com/go-gl/glow/gl-core/3.3/gl"
-	gl4 "github.com/go-gl/glow/gl-core/4.4/gl"
 	"github.com/go-gl/mathgl/mgl32"
 	"image"
 	"image/draw"
@@ -71,8 +71,8 @@ func main() {
 	}
 
 	// Note that it is possible to use GL functions spanning multiple versions
-	if err := gl4.Init(); err != nil {
-		fmt.Println("Could not initialize GL 4.4 (non-fatal)")
+	if err := gl32.Init(); err != nil {
+		fmt.Println("Could not initialize GL 3.2 (non-fatal)")
 	}
 
 	version := gl.GoStr(gl.GetString(gl.VERSION))


### PR DESCRIPTION
Using GL 4.4 is misleading because the example asks for a version-3.3 context which may not contain future-version functions. In general this is a tricky combination to get right in production code but this example simply demonstrates it is possible to initialize two glow packages in the same program.

Fixes go-gl/glow/#45.
