### PR TITLE
Add import comments.

### DIFF
--- a/gl21-cube/cube.go
+++ b/gl21-cube/cube.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Renders a textured spinning cube using GLFW 3 and OpenGL 2.1.
-package main
+package main // import "github.com/go-gl/example/gl21-cube"
 
 import (
 	"go/build"

--- a/gl41core-cube/cube.go
+++ b/gl41core-cube/cube.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Renders a textured spinning cube using GLFW 3 and OpenGL 4.1 core forward-compatible profile.
-package main
+package main // import "github.com/go-gl/example/gl41core-cube"
 
 import (
 	"fmt"


### PR DESCRIPTION
The repository has been recently renamed from "examples" to "example" in #58. Help make the new expected import path more clear by adding import comments. (Reference: https://golang.org/cmd/go/#hdr-Import_path_checking.)

This way, the expected import path is visible in the source code, in addition to README. It also gives a better error message when trying to `go get` or `go install` the package with incorrect old import path.

Closes #58 (again).