### PR TITLE
Update importPathToDir() to use x/tools/go/packages

### DIFF
--- a/gl21-cube/cube.go
+++ b/gl21-cube/cube.go
@@ -6,13 +6,15 @@
 package main // import "github.com/go-gl/example/gl21-cube"
 
 import (
-	"go/build"
 	"image"
 	"image/draw"
 	_ "image/png"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
+
+	"golang.org/x/tools/go/packages"
 
 	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
@@ -220,9 +222,10 @@ func init() {
 // There doesn't need to be a valid Go package inside that import path,
 // but the directory must exist.
 func importPathToDir(importPath string) (string, error) {
-	p, err := build.Import(importPath, "", build.FindOnly)
+	c := packages.Config{Mode: packages.LoadFiles}
+	p, err := packages.Load(&c, importPath)
 	if err != nil {
 		return "", err
 	}
-	return p.Dir, nil
+	return filepath.Dir(p[0].GoFiles[0]), nil
 }

--- a/gl41core-cube/cube.go
+++ b/gl41core-cube/cube.go
@@ -7,14 +7,16 @@ package main // import "github.com/go-gl/example/gl41core-cube"
 
 import (
 	"fmt"
-	"go/build"
 	"image"
 	"image/draw"
 	_ "image/png"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 
 	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
@@ -334,9 +336,10 @@ func init() {
 // There doesn't need to be a valid Go package inside that import path,
 // but the directory must exist.
 func importPathToDir(importPath string) (string, error) {
-	p, err := build.Import(importPath, "", build.FindOnly)
+	c := packages.Config{Mode: packages.LoadFiles}
+	p, err := packages.Load(&c, importPath)
 	if err != nil {
 		return "", err
 	}
-	return p.Dir, nil
+	return filepath.Dir(p[0].GoFiles[0]), nil
 }


### PR DESCRIPTION
Example was not working when using go modules, got 
```
"Unable to find Go Package in your GOPATH, it's needed to load assets: cannot find package "github.com/go-gl/example/gl41core-cube" in any of: 
  C:\Go\src\github.com\go-gl\example\gl41core-cube (from $GOROOT)
  C:\Users\agreen\go\src\github.com\go-gl\example\gl41core-cube (from $GOPATH)
```

See https://github.com/golang/go/issues/29952#issuecomment-457914790