### PR TITLE
Fix the aspect ratio in the GL 2.1 example

### DIFF
--- a/gl21-cube/cube.go
+++ b/gl21-cube/cube.go
@@ -117,7 +117,7 @@ func setupScene() {
 
 	gl.MatrixMode(gl.PROJECTION)
 	gl.LoadIdentity()
-	f := ((float64(width) / height) - 1) / 2
+	f := float64(width)/height - 1
 	gl.Frustum(-1-f, 1+f, -1, 1, 1.0, 10.0)
 	gl.MatrixMode(gl.MODELVIEW)
 	gl.LoadIdentity()


### PR DESCRIPTION
Given the 4:3 aspect ratio, `f` comes out to 0.1(6). When you now define frustum in the next line, you get an aspect ratio of 2.(3):2 or 7:6, and the resulting cube is squished. Not much, but enough to feel off.