### PR TITLE
Reordered null at the end of strings for clarity.

### DIFF
--- a/gl41core-cube/cube.go
+++ b/gl41core-cube/cube.go
@@ -177,7 +177,7 @@ func newProgram(vertexShaderSource, fragmentShaderSource string) (uint32, error)
 func compileShader(source string, shaderType uint32) (uint32, error) {
 	shader := gl.CreateShader(shaderType)
 
-	csources, free := gl.Strs(source)
+	csources, free := gl.Strs(source + "\x00")
 	gl.ShaderSource(shader, 1, csources, nil)
 	free()
 	gl.CompileShader(shader)
@@ -251,7 +251,7 @@ void main() {
     fragTexCoord = vertTexCoord;
     gl_Position = projection * camera * model * vec4(vert, 1);
 }
-` + "\x00"
+`
 
 var fragmentShader = `
 #version 330
@@ -265,7 +265,7 @@ out vec4 outputColor;
 void main() {
     outputColor = texture(tex, fragTexCoord);
 }
-` + "\x00"
+`
 
 var cubeVertices = []float32{
 	//  X, Y, Z, U, V


### PR DESCRIPTION
I had issues just following the code when it comes to null termination. Usually in go you don't deal with worrying about strings having them, so I reordered it such that the null is added inside the `compileShader` code rather than it already existing on the strings.

I'm creating this PR as in my opinion it is much clearer at a glance that this is neccesary, as some people (like me) will skip over the addition on the shader sources and would pay closer attention to the compileShader function, assuming the input string is standard & hasn't been doctored beforehand to deal with the idiosyncrasies of needing to worry about null at the end of strings.